### PR TITLE
Injector binding improved

### DIFF
--- a/silver-hammer-core/src/main/java/ru/silverhammer/common/injection/Injector.java
+++ b/silver-hammer-core/src/main/java/ru/silverhammer/common/injection/Injector.java
@@ -168,7 +168,7 @@ public class Injector {
 		if (namedBindings == null) {
 			final Map<String, IBound<?>> subTypedNamedBindings = new HashMap<>();
 			bindings.entrySet().stream()
-					.filter(e -> e.getKey().isAssignableFrom(type))
+					.filter(e -> type.isAssignableFrom(e.getKey()))
 					.map(Map.Entry::getValue)
 					.forEach(subTypedNamedBindings::putAll);
 			if (subTypedNamedBindings.size() > 0) {


### PR DESCRIPTION
changed binding search: if Injector couldn't find binding for the type, it will try to iterate over bindings map and collect all found subtype binding into one named binding map. Can be useful when bindings are initialized by a subtype, but the constructor uses base type argument